### PR TITLE
Fix for PHP7 warning

### DIFF
--- a/menu-limit-detector.php
+++ b/menu-limit-detector.php
@@ -89,7 +89,7 @@ function mldetect_count_post_vars() {
 
 		$count = 0;
 		foreach( $_POST as $key => $arr ){
-			$count+= count( $arr );
+			$count+= count ( array ( $arr ) );
 		}
 
 		update_option( 'mldetect-post-var-count' , $count );


### PR DESCRIPTION
Wrapped $arr in array() function to prevent below PHP 7.2 warning:
Warning: count(): Parameter must be an array or an object that implements Countable